### PR TITLE
fix: prevent Cloudflare from caching dynamic content

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -8,7 +8,18 @@
 /build/*
   Cache-Control: public, max-age=31536000, s-maxage=31536000, immutable
 
+# Static assets that can be cached
+/favicon.ico
+  Cache-Control: public, max-age=86400
+
+/manifest.json
+  Cache-Control: public, max-age=86400
+
+# Prevent caching of all other pages and API routes
 /*
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
   # Security Headers for WebAuthn Support
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff


### PR DESCRIPTION
## Summary
- Add comprehensive no-cache headers for all routes (`/*`) to prevent Cloudflare from caching pages and API routes
- Keep selective caching for static build assets (`/build/*`) and basic static files (favicon.ico, manifest.json)
- Preserve all existing security headers for WebAuthn support

## Test plan
- [ ] Deploy to Cloudflare Pages and verify dynamic content is not cached
- [ ] Confirm static assets are still properly cached with appropriate cache times
- [ ] Verify security headers remain intact for WebAuthn functionality

🤖 Generated with [Claude Code](https://claude.ai/code)