### PR TITLE
Refactor OAuth callbacks to use shared user service

### DIFF
--- a/src/lib/auth/user-service.ts
+++ b/src/lib/auth/user-service.ts
@@ -1,0 +1,57 @@
+import type { RequestEventCommon } from "@builder.io/qwik-city";
+import { eq } from "drizzle-orm";
+import { getDB, users } from "~/lib/db";
+import { generateUserId } from "./utils";
+
+interface UserProfile {
+  email: string;
+  name?: string;
+  picture?: string | null;
+  provider: "google" | "apple";
+  providerId: string;
+}
+
+/**
+ * Find an existing user by email or create a new one
+ */
+export const findOrCreateUser = async (
+  event: RequestEventCommon,
+  profile: UserProfile
+): Promise<string> => {
+  const db = getDB(event);
+
+  // Check if user already exists
+  const existingUser = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, profile.email))
+    .limit(1);
+
+  let userId: string;
+
+  if (existingUser.length > 0) {
+    // Just update the timestamp
+    userId = existingUser[0].id;
+    await db
+      .update(users)
+      .set({
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
+  } else {
+    // Create new user
+    userId = generateUserId();
+    await db.insert(users).values({
+      id: userId,
+      email: profile.email,
+      name: profile.name || profile.email.split("@")[0], // Fallback display name
+      picture: profile.picture,
+      provider: profile.provider,
+      providerId: profile.providerId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  }
+
+  return userId;
+};


### PR DESCRIPTION
## Summary

- Extracted duplicated user lookup/creation logic into a shared `findOrCreateUser` function
- Refactored both Google and Apple OAuth callbacks to use the common service
- Eliminated ~60 lines of duplicated database code while maintaining identical functionality

## Changes

- **New**: `src/lib/auth/user-service.ts` - Common user management service
- **Updated**: Google OAuth callback - Uses shared service for user operations  
- **Updated**: Apple OAuth callback - Uses shared service for user operations
- **Removed**: Duplicated database queries and user creation logic

## Test Plan

- [x] TypeScript compilation passes
- [x] Application builds successfully (client + server)
- [x] Lint checks pass
- [x] Code maintains identical functionality
- [x] Both OAuth flows use the same tested user management logic

🤖 Generated with [Claude Code](https://claude.ai/code)