### PR TITLE
Fix OIDC response header error by simplifying endpoint approach

### DIFF
--- a/src/routes/oidc/[...path]/index.ts
+++ b/src/routes/oidc/[...path]/index.ts
@@ -1,99 +1,52 @@
 import type { RequestHandler } from '@builder.io/qwik-city';
-import { getCachedOIDCProvider } from '../../../lib/auth/provider-cache';
 
 /**
- * OIDC Provider endpoint handler
- * Handles all OpenID Connect endpoints:
+ * OIDC Provider catch-all endpoint handler
+ * Handles OpenID Connect discovery endpoint:
  * - /.well-known/openid_configuration
- * - /auth (authorization endpoint)
- * - /token (token endpoint)
- * - /userinfo (userinfo endpoint)
- * - /jwks (JSON Web Key Set)
- * - /revocation (token revocation)
- * - /introspection (token introspection)
+ * 
+ * Other OIDC endpoints are handled by their specific route files:
+ * - /auth -> /oidc/auth/index.ts
+ * - /token -> /oidc/token/index.ts
+ * - /userinfo -> /oidc/userinfo/index.ts
+ * - /jwks -> /oidc/jwks/index.ts
+ * - /revocation -> /oidc/revocation/index.ts
+ * - /introspection -> /oidc/introspection/index.ts
  */
 export const onRequest: RequestHandler = async (event) => {
   try {
-    // Get the issuer URL (base URL for OIDC)
-    const issuer = `${event.url.protocol}//${event.url.host}/oidc`;
-    
-    // Get cached OIDC provider instance
-    const provider = await getCachedOIDCProvider(issuer, event);
-
-    // Handle the OIDC request
-    const callback = provider.callback();
-    
-    // Create a response object that oidc-provider expects
-    let responseStatus = 200;
-    const responseHeaders = new Headers();
-    let responseBody = '';
-
-    const mockResponse = {
-      headers: responseHeaders,
-      res: {
-        setHeader: (name: string, value: string) => {
-          responseHeaders.set(name, value);
-        },
-        getHeader: (name: string) => {
-          return responseHeaders.get(name);
-        },
-        statusCode: responseStatus,
-      },
+    // Handle .well-known/openid_configuration endpoint
+    if (event.url.pathname.endsWith('/.well-known/openid_configuration')) {
+      const issuer = `${event.url.protocol}//${event.url.host}/oidc`;
       
-      // Header methods
-      set(name: string, value: string) {
-        responseHeaders.set(name, value);
-        this.res.statusCode = responseStatus;
-      },
+      const config = {
+        issuer,
+        authorization_endpoint: `${issuer}/auth`,
+        token_endpoint: `${issuer}/token`,
+        userinfo_endpoint: `${issuer}/userinfo`,
+        jwks_uri: `${issuer}/jwks`,
+        revocation_endpoint: `${issuer}/revocation`,
+        introspection_endpoint: `${issuer}/introspection`,
+        response_types_supported: ['code', 'id_token', 'code id_token'],
+        subject_types_supported: ['public'],
+        id_token_signing_alg_values_supported: ['RS256'],
+        scopes_supported: ['openid', 'profile', 'email'],
+        token_endpoint_auth_methods_supported: ['none', 'client_secret_basic', 'client_secret_post'],
+        claims_supported: ['sub', 'name', 'email', 'picture', 'email_verified'],
+        code_challenge_methods_supported: ['S256'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+      };
       
-      get(name: string) {
-        return responseHeaders.get(name);
-      },
-      
-      // Body setter
-      set body(content: any) {
-        responseBody = content;
-      },
-      
-      get body() {
-        return responseBody;
-      },
+      event.json(200, config);
+      return;
+    }
 
-      // Status setter/getter
-      set status(code: number) {
-        responseStatus = code;
-        this.res.statusCode = code;
-      },
-      
-      get status() {
-        return responseStatus;
-      },
-
-      // Type setter/getter (for Koa compatibility)
-      set type(value: string) {
-        responseHeaders.set('Content-Type', value);
-      },
-      
-      get type() {
-        return responseHeaders.get('Content-Type') || '';
-      },
-
-      // Redirect method
-      redirect(url: string) {
-        responseStatus = 302;
-        this.res.statusCode = 302;
-        responseHeaders.set('Location', url);
-      },
-    };
-
-    // Call the OIDC provider with the request and response
-    await callback(event.request as any, mockResponse as any);
-
-    // Send the response from OIDC provider
-    event.send(new Response(responseBody, {
-      status: responseStatus,
-      headers: responseHeaders,
-    }));
+    // Return 404 for any other unhandled paths
+    event.json(404, {
+      error: 'not_found',
+      error_description: 'OIDC endpoint not found',
+      endpoint: event.url.pathname,
+    });
 
   } catch (error) {
     console.error('OIDC Provider error:', error);


### PR DESCRIPTION
## Summary

- Fixes `TypeError: this.res.setHeader is not a function` in OIDC endpoints
- Replaces complex oidc-provider Koa integration with native Qwik City methods
- Implements proper `.well-known/openid_configuration` endpoint using `event.json()`
- Adds placeholder responses for unimplemented endpoints

## Background

The previous implementation attempted to integrate the `oidc-provider` library (designed for Koa.js) with Qwik City by creating mock response objects. This caused runtime errors because the library expected full Koa context objects with proper Node.js HTTP response prototypes.

## Solution

- Individual OIDC endpoints (`/jwks`, `/auth`, etc.) already work correctly using native Qwik City methods
- The catch-all `[...path]` route now handles only the OpenID Connect discovery endpoint
- All endpoints now use proper Qwik City response methods (`event.json()`, `event.redirect()`, etc.)

## Test Plan

- [x] Verify `.well-known/openid_configuration` returns proper OIDC metadata
- [x] Confirm other endpoints (like `/jwks`) continue working
- [x] Ensure no `TypeError: this.res.setHeader is not a function` errors
- [x] Check that development server starts without errors

🤖 Generated with [Claude Code](https://claude.ai/code)